### PR TITLE
Update header from `x-now` to `x-vercel`

### DIFF
--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -293,7 +293,7 @@ function Content({ isEdit, edits }: { isEdit: boolean; edits: FieldEdit[] }) {
             isActive={isEdit}
             edits={edits}
           >
-            curl -sI https://next-preview.now.sh | grep x-now
+            curl -sI https://next-preview.now.sh | grep x-vercel
           </Malleable>
           <Malleable
             id="explanation-1-pre-response"

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -302,11 +302,11 @@ function Content({ isEdit, edits }: { isEdit: boolean; edits: FieldEdit[] }) {
             isActive={isEdit}
             edits={edits}
           >
-            x-now-cache: HIT
+            x-vercel-cache: HIT
             <br />
-            x-now-trace: sfo1
+            x-vercel-trace: sfo1
             <br />
-            x-now-id: sfo1:7c7lc-1583269874370-6a496f5a4e91
+            x-vercel-id: sfo1:7c7lc-1583269874370-6a496f5a4e91
           </Malleable>
         </div>
         <Malleable id="explanation-2" isActive={isEdit} edits={edits}>


### PR DESCRIPTION
Hey y'all,

I just noticed that the response headers have been changed with the renaming of the company :)

`now` -> `vercel`